### PR TITLE
Add checks for number of arguments in the transaction

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -14,7 +14,7 @@ export declare class Account {
     private _state;
     private _accessKey;
     private _ready;
-    protected get ready(): Promise<void>;
+    protected readonly ready: Promise<void>;
     constructor(connection: Connection, accountId: string);
     fetchState(): Promise<void>;
     state(): Promise<AccountState>;

--- a/lib/account.js
+++ b/lib/account.js
@@ -20,12 +20,12 @@ function sleep(millis) {
     return new Promise(resolve => setTimeout(resolve, millis));
 }
 class Account {
+    get ready() {
+        return this._ready || (this._ready = Promise.resolve(this.fetchState()));
+    }
     constructor(connection, accountId) {
         this.connection = connection;
         this.accountId = accountId;
-    }
-    get ready() {
-        return this._ready || (this._ready = Promise.resolve(this.fetchState()));
     }
     async fetchState() {
         this._accessKey = null;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -20,6 +20,9 @@ class AccessKey extends enums_1.Assignable {
 }
 exports.AccessKey = AccessKey;
 function fullAccessKey() {
+    if (arguments.length != 0) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected none`);
+    }
     return new AccessKey({ nonce: 0, permission: new AccessKeyPermission({ fullAccess: new FullAccessPermission({}) }) });
 }
 exports.fullAccessKey = fullAccessKey;
@@ -47,34 +50,58 @@ class DeleteKey extends IAction {
 class DeleteAccount extends IAction {
 }
 function createAccount() {
+    if (arguments.length != 0) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected none`);
+    }
     return new Action({ createAccount: new CreateAccount({}) });
 }
 exports.createAccount = createAccount;
 function deployContract(code) {
+    if (arguments.length != 1) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected code`);
+    }
     return new Action({ deployContract: new DeployContract({ code }) });
 }
 exports.deployContract = deployContract;
 function functionCall(methodName, args, gas, deposit) {
+    if (arguments.length != 4) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected methodName, args, gas, deposit`);
+    }
     return new Action({ functionCall: new FunctionCall({ methodName, args, gas, deposit }) });
 }
 exports.functionCall = functionCall;
 function transfer(deposit) {
+    if (arguments.length != 1) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected deposit`);
+    }
     return new Action({ transfer: new Transfer({ deposit }) });
 }
 exports.transfer = transfer;
 function stake(stake, publicKey) {
+    if (arguments.length != 2) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected stake and publicKey`);
+    }
     return new Action({ stake: new Stake({ stake, publicKey }) });
 }
 exports.stake = stake;
 function addKey(publicKey, accessKey) {
+    if (arguments.length != 2) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected publicKey and accessKey`);
+    }
     return new Action({ addKey: new AddKey({ publicKey, accessKey }) });
 }
 exports.addKey = addKey;
 function deleteKey(publicKey) {
+    if (arguments.length != 1) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected publicKey`);
+    }
     return new Action({ deleteKey: new DeleteKey({ publicKey }) });
 }
 exports.deleteKey = deleteKey;
 function deleteAccount(beneficiaryId) {
+    if (arguments.length != 1) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected beneficiaryId`);
+    }
     return new Action({ deleteAccount: new DeleteAccount({ beneficiaryId }) });
 }
 exports.deleteAccount = deleteAccount;

--- a/src.ts/transaction.ts
+++ b/src.ts/transaction.ts
@@ -27,6 +27,9 @@ export class AccessKey extends Assignable {
 }
 
 export function fullAccessKey(): AccessKey {
+    if (arguments.length != 0) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected none`);
+    }
     return new AccessKey({ nonce: 0, permission: new AccessKeyPermission({fullAccess: new FullAccessPermission({})}) });
 }
 
@@ -46,34 +49,58 @@ class DeleteKey extends IAction { publicKey: PublicKey; }
 class DeleteAccount extends IAction { beneficiaryId: string; }
 
 export function createAccount(): Action {
+    if (arguments.length != 0) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected none`);
+    }
     return new Action({createAccount: new CreateAccount({}) });
 }
 
 export function deployContract(code: Uint8Array): Action {
+    if (arguments.length != 1) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected code`);
+    }
     return new Action({ deployContract: new DeployContract({code}) });
 }
 
 export function functionCall(methodName: string, args: Uint8Array, gas: number, deposit: BN): Action {
+    if (arguments.length != 4) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected methodName, args, gas, deposit`);
+    }
     return new Action({functionCall: new FunctionCall({methodName, args, gas, deposit }) });
 }
 
 export function transfer(deposit: BN): Action {
+    if (arguments.length != 1) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected deposit`);
+    }
     return new Action({transfer: new Transfer({ deposit }) });
 }
 
 export function stake(stake: BN, publicKey: PublicKey): Action {
+    if (arguments.length != 2) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected stake and publicKey`);
+    }
     return new Action({stake: new Stake({ stake, publicKey }) });
 }
 
 export function addKey(publicKey: PublicKey, accessKey: AccessKey): Action {
+    if (arguments.length != 2) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected publicKey and accessKey`);
+    }
     return new Action({addKey: new AddKey({ publicKey, accessKey}) });
 }
 
 export function deleteKey(publicKey: PublicKey): Action {
+    if (arguments.length != 1) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected publicKey`);
+    }
     return new Action({deleteKey: new DeleteKey({ publicKey }) });
 }
 
 export function deleteAccount(beneficiaryId: string): Action {
+    if (arguments.length != 1) {
+        throw new Error(`Wrong number of arguments ${arguments.length}: expected beneficiaryId`);
+    }
     return new Action({deleteAccount: new DeleteAccount({ beneficiaryId }) });
 }
 

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -1,0 +1,30 @@
+const nearlib = require('../lib/index');
+const sha256 = require('js-sha256');
+
+test('wrong number of arguments', () => {
+    expect(() => nearlib.transactions.createAccount(1,2)).toThrow();
+    expect(() => nearlib.transactions.deployContract()).toThrow();
+    expect(() => nearlib.transactions.transfer()).toThrow();
+    expect(() => nearlib.transactions.functionCall()).toThrow();
+    expect(() => nearlib.transactions.stake(123)).toThrow();
+    expect(() => nearlib.transactions.addKey('')).toThrow();
+    expect(() => nearlib.transactions.deleteKey('', '')).toThrow();
+    expect(() => nearlib.transactions.deleteAccount()).toThrow();
+});
+
+test('serialize transaction', () => {
+    const keyPair = nearlib.utils.key_pair.KeyPair.fromString('ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw');
+    const publicKey = keyPair.publicKey.toString();
+    var transaction = nearlib.transactions.createTransaction('kiwi', keyPair.publicKey, 'speed', 1, [
+        nearlib.transactions.createAccount(), 
+        nearlib.transactions.transfer(0.1), 
+        nearlib.transactions.addKey(
+            nearlib.utils.key_pair.PublicKey.from(publicKey),
+            nearlib.transactions.fullAccessKey()),
+        ], 
+        '0PL893ZxHbyJuAfVW3wb9vJ7Sqcs2LGa');
+    const bytes = transaction.encode();
+    const newTransaction = nearlib.transactions.Transaction.decode(bytes);
+    const signingPayload = new Uint8Array(sha256.sha256.array(newTransaction.encode()));
+    expect(nearlib.utils.serialize.base_encode(signingPayload)).toEqual('7BPy3DwqhcYg4Trr5RRb2nhVKTswz6kmBXUKReWzpxGQ');
+});


### PR DESCRIPTION
Errors otherwise are unintelligible.

Is there a better way to do this?