### PR TITLE
Change signTransaction to take transaction object

### DIFF
--- a/lib/transaction.d.ts
+++ b/lib/transaction.d.ts
@@ -90,5 +90,6 @@ export declare class Action extends Enum {
 }
 export declare const SCHEMA: Map<Function, any>;
 export declare function createTransaction(signerId: string, publicKey: PublicKey, receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array): Transaction;
+export declare function signTransactionObject(transaction: Transaction, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
 export declare function signTransaction(receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
 export {};

--- a/lib/transaction.d.ts
+++ b/lib/transaction.d.ts
@@ -90,6 +90,6 @@ export declare class Action extends Enum {
 }
 export declare const SCHEMA: Map<Function, any>;
 export declare function createTransaction(signerId: string, publicKey: PublicKey, receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array): Transaction;
-export declare function signTransactionObject(transaction: Transaction, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
+export declare function signTransaction(transaction: Transaction, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
 export declare function signTransaction(receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
 export {};

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -179,20 +179,25 @@ function createTransaction(signerId, publicKey, receiverId, nonce, actions, bloc
 }
 exports.createTransaction = createTransaction;
 async function signTransactionObject(transaction, signer, accountId, networkId) {
-    const publicKey = await signer.getPublicKey(accountId, networkId);
     const message = serialize_1.serialize(exports.SCHEMA, transaction);
     const hash = new Uint8Array(js_sha256_1.default.sha256.array(message));
     const signature = await signer.signMessage(message, accountId, networkId);
     const signedTx = new SignedTransaction({
         transaction,
-        signature: new Signature({ keyType: publicKey.keyType, data: signature.signature })
+        signature: new Signature({ keyType: transaction.publicKey.keyType, data: signature.signature })
     });
     return [hash, signedTx];
 }
-exports.signTransactionObject = signTransactionObject;
-async function signTransaction(receiverId, nonce, actions, blockHash, signer, accountId, networkId) {
-    const publicKey = await signer.getPublicKey(accountId, networkId);
-    const transaction = createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
-    return signTransactionObject(transaction, signer, accountId, networkId);
+async function signTransaction(...args) {
+    if (args[0].constructor === Transaction) {
+        let [transaction, signer, accountId, networkId] = args;
+        return signTransactionObject(transaction, signer, accountId, networkId);
+    }
+    else {
+        let [receiverId, nonce, actions, blockHash, signer, accountId, networkId] = args;
+        const publicKey = await signer.getPublicKey(accountId, networkId);
+        const transaction = createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
+        return signTransactionObject(transaction, signer, accountId, networkId);
+    }
 }
 exports.signTransaction = signTransaction;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -190,11 +190,11 @@ async function signTransactionObject(transaction, signer, accountId, networkId) 
 }
 async function signTransaction(...args) {
     if (args[0].constructor === Transaction) {
-        let [transaction, signer, accountId, networkId] = args;
+        const [transaction, signer, accountId, networkId] = args;
         return signTransactionObject(transaction, signer, accountId, networkId);
     }
     else {
-        let [receiverId, nonce, actions, blockHash, signer, accountId, networkId] = args;
+        const [receiverId, nonce, actions, blockHash, signer, accountId, networkId] = args;
         const publicKey = await signer.getPublicKey(accountId, networkId);
         const transaction = createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
         return signTransactionObject(transaction, signer, accountId, networkId);

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -178,9 +178,8 @@ function createTransaction(signerId, publicKey, receiverId, nonce, actions, bloc
     return new Transaction({ signerId, publicKey, nonce, receiverId, actions, blockHash });
 }
 exports.createTransaction = createTransaction;
-async function signTransaction(receiverId, nonce, actions, blockHash, signer, accountId, networkId) {
+async function signTransactionObject(transaction, signer, accountId, networkId) {
     const publicKey = await signer.getPublicKey(accountId, networkId);
-    const transaction = createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
     const message = serialize_1.serialize(exports.SCHEMA, transaction);
     const hash = new Uint8Array(js_sha256_1.default.sha256.array(message));
     const signature = await signer.signMessage(message, accountId, networkId);
@@ -189,5 +188,11 @@ async function signTransaction(receiverId, nonce, actions, blockHash, signer, ac
         signature: new Signature({ keyType: publicKey.keyType, data: signature.signature })
     });
     return [hash, signedTx];
+}
+exports.signTransactionObject = signTransactionObject;
+async function signTransaction(receiverId, nonce, actions, blockHash, signer, accountId, networkId) {
+    const publicKey = await signer.getPublicKey(accountId, networkId);
+    const transaction = createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
+    return signTransactionObject(transaction, signer, accountId, networkId);
 }
 exports.signTransaction = signTransaction;

--- a/src.ts/transaction.ts
+++ b/src.ts/transaction.ts
@@ -201,9 +201,8 @@ export function createTransaction(signerId: string, publicKey: PublicKey, receiv
     return new Transaction({ signerId, publicKey, nonce, receiverId, actions, blockHash });
 }
 
-export async function signTransaction(receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]> {
+export async function signTransactionObject(transaction: Transaction, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]> {
     const publicKey = await signer.getPublicKey(accountId, networkId);
-    const transaction = createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
     const message = serialize(SCHEMA, transaction);
     const hash = new Uint8Array(sha256.sha256.array(message));
     const signature = await signer.signMessage(message, accountId, networkId);
@@ -212,4 +211,10 @@ export async function signTransaction(receiverId: string, nonce: number, actions
         signature: new Signature({ keyType: publicKey.keyType, data: signature.signature })
     });
     return [hash, signedTx];
+}
+
+export async function signTransaction(receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]> {
+    const publicKey = await signer.getPublicKey(accountId, networkId);
+    const transaction = createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
+    return signTransactionObject(transaction, signer, accountId, networkId);
 }

--- a/src.ts/transaction.ts
+++ b/src.ts/transaction.ts
@@ -216,10 +216,10 @@ export async function signTransaction(transaction: Transaction, signer: Signer, 
 export async function signTransaction(receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
 export async function signTransaction(...args): Promise<[Uint8Array, SignedTransaction]> {
     if (args[0].constructor === Transaction) {
-        let [ transaction, signer, accountId, networkId ] = args;
+        const [ transaction, signer, accountId, networkId ] = args;
         return signTransactionObject(transaction, signer, accountId, networkId);
     } else {
-        let [ receiverId, nonce, actions, blockHash, signer, accountId, networkId ] = args;
+        const [ receiverId, nonce, actions, blockHash, signer, accountId, networkId ] = args;
         const publicKey = await signer.getPublicKey(accountId, networkId);
         const transaction = createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
         return signTransactionObject(transaction, signer, accountId, networkId);

--- a/src.ts/transaction.ts
+++ b/src.ts/transaction.ts
@@ -201,20 +201,27 @@ export function createTransaction(signerId: string, publicKey: PublicKey, receiv
     return new Transaction({ signerId, publicKey, nonce, receiverId, actions, blockHash });
 }
 
-export async function signTransactionObject(transaction: Transaction, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]> {
-    const publicKey = await signer.getPublicKey(accountId, networkId);
+async function signTransactionObject(transaction: Transaction, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]> {
     const message = serialize(SCHEMA, transaction);
     const hash = new Uint8Array(sha256.sha256.array(message));
     const signature = await signer.signMessage(message, accountId, networkId);
     const signedTx = new SignedTransaction({
         transaction,
-        signature: new Signature({ keyType: publicKey.keyType, data: signature.signature })
+        signature: new Signature({ keyType: transaction.publicKey.keyType, data: signature.signature })
     });
     return [hash, signedTx];
 }
 
-export async function signTransaction(receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]> {
-    const publicKey = await signer.getPublicKey(accountId, networkId);
-    const transaction = createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
-    return signTransactionObject(transaction, signer, accountId, networkId);
+export async function signTransaction(transaction: Transaction, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
+export async function signTransaction(receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
+export async function signTransaction(...args): Promise<[Uint8Array, SignedTransaction]> {
+    if (args[0].constructor === Transaction) {
+        let [ transaction, signer, accountId, networkId ] = args;
+        return signTransactionObject(transaction, signer, accountId, networkId);
+    } else {
+        let [ receiverId, nonce, actions, blockHash, signer, accountId, networkId ] = args;
+        const publicKey = await signer.getPublicKey(accountId, networkId);
+        const transaction = createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
+        return signTransactionObject(transaction, signer, accountId, networkId);
+    }
 }

--- a/test/serialize.test.js
+++ b/test/serialize.test.js
@@ -36,18 +36,23 @@ test('serialize and sign multi-action tx', async() => {
     expect(nearlib.utils.serialize.base_encode(hash)).toEqual('Fo3MJ9XzKjnKuDuQKhDAC6fra5H2UWawRejFSEpPNk3Y');
 });
 
-test('serialize transfer tx', async() => {
+function createTransferTx() {
     const actions = [
         nearlib.transactions.transfer(1),
     ];
     const blockHash = nearlib.utils.serialize.base_decode('244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM');
-    const transaction = nearlib.transactions.createTransaction(
+    return nearlib.transactions.createTransaction(
         'test.near',
         nearlib.utils.PublicKey.fromString('Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC'),
         'whatever.near',
         1,
         actions,
         blockHash);
+}
+
+test('serialize transfer tx', async() => {
+    const transaction = createTransferTx();
+
     const serialized = transaction.encode();
     expect(serialized.toString('hex')).toEqual('09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef6010000000301000000000000000000000000000000');
 
@@ -55,23 +60,38 @@ test('serialize transfer tx', async() => {
     expect(deserialized.encode()).toEqual(serialized);
 });
 
-test('serialize and sign transfer tx', async() => {
+async function createKeyStore() {
     const keyStore = new nearlib.keyStores.InMemoryKeyStore();
     const keyPair = nearlib.utils.KeyPair.fromString('ed25519:3hoMW1HvnRLSFCLZnvPzWeoGwtdHzke34B2cTHM8rhcbG3TbuLKtShTv3DvyejnXKXKBiV7YPkLeqUHN1ghnqpFv');
     await keyStore.setKey('test', 'test.near', keyPair);
-    const actions = [
-        nearlib.transactions.transfer(1),
-    ];
-    const blockHash = nearlib.utils.serialize.base_decode('244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM');
+    return keyStore;
+}
 
-    let [, signedTx] = await nearlib.transactions.signTransaction('whatever.near', 1, actions, blockHash, new nearlib.InMemorySigner(keyStore), 'test.near', 'test');
-
+async function verifySignedTransferTx(signedTx) {
     expect(Buffer.from(signedTx.signature.data).toString('base64')).toEqual('lpqDMyGG7pdV5IOTJVJYBuGJo9LSu0tHYOlEQ+l+HE8i3u7wBZqOlxMQDtpuGRRNp+ig735TmyBwi6HY0CG9AQ==');
     const serialized = signedTx.encode();
     expect(serialized.toString('hex')).toEqual('09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef601000000030100000000000000000000000000000000969a83332186ee9755e4839325525806e189a3d2d2bb4b4760e94443e97e1c4f22deeef0059a8e9713100eda6e19144da7e8a0ef7e539b20708ba1d8d021bd01');
     
     const deserialized = nearlib.transactions.SignedTransaction.decode(serialized);
     expect(deserialized.encode()).toEqual(serialized);
+}
+
+test('serialize and sign transfer tx', async() => {
+    const transaction = createTransferTx();
+    const keyStore = await createKeyStore();
+
+    let [, signedTx] = await nearlib.transactions.signTransaction(transaction.receiverId, transaction.nonce, transaction.actions, transaction.blockHash, new nearlib.InMemorySigner(keyStore), 'test.near', 'test');
+
+    verifySignedTransferTx(signedTx);
+});
+
+test('serialize and sign transfer tx object', async() => {
+    const transaction = createTransferTx();
+    const keyStore = await createKeyStore();
+
+    let [, signedTx] = await nearlib.transactions.signTransaction(transaction, new nearlib.InMemorySigner(keyStore), 'test.near', 'test');
+
+    verifySignedTransferTx(signedTx);
 });
 
 describe('roundtrip test', () => {


### PR DESCRIPTION
Change signTransaction to take transaction object so that transaction signing can be separated from transaction creation.