### PR TITLE
Increase default gas amount for function calls

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -13,7 +13,7 @@ export declare class Account {
     readonly accountId: string;
     private _state;
     private _ready;
-    protected readonly ready: Promise<void>;
+    protected get ready(): Promise<void>;
     constructor(connection: Connection, accountId: string);
     fetchState(): Promise<void>;
     state(): Promise<AccountState>;
@@ -26,7 +26,7 @@ export declare class Account {
     createAccount(newAccountId: string, publicKey: string | PublicKey, amount: BN): Promise<FinalExecutionOutcome>;
     deleteAccount(beneficiaryId: string): Promise<FinalExecutionOutcome>;
     deployContract(data: Uint8Array): Promise<FinalExecutionOutcome>;
-    functionCall(contractId: string, methodName: string, args: any, gas: number, amount?: BN): Promise<FinalExecutionOutcome>;
+    functionCall(contractId: string, methodName: string, args: any, gas?: BN, amount?: BN): Promise<FinalExecutionOutcome>;
     addKey(publicKey: string | PublicKey, contractId?: string, methodName?: string, amount?: BN): Promise<FinalExecutionOutcome>;
     deleteKey(publicKey: string | PublicKey): Promise<FinalExecutionOutcome>;
     stake(publicKey: string | PublicKey, amount: BN): Promise<FinalExecutionOutcome>;

--- a/lib/account.js
+++ b/lib/account.js
@@ -1,15 +1,21 @@
 'use strict';
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
+const bn_js_1 = __importDefault(require("bn.js"));
 const transaction_1 = require("./transaction");
 const providers_1 = require("./providers");
 const serialize_1 = require("./utils/serialize");
 const key_pair_1 = require("./utils/key_pair");
 const errors_1 = require("./utils/errors");
 const rpc_errors_1 = require("./utils/rpc_errors");
-// Default amount of tokens to be send with the function calls. Used to pay for the fees
+// Default amount of gas to be sent with the function calls. Used to pay for the fees
 // incurred while running the contract execution. The unused amount will be refunded back to
 // the originator.
-const DEFAULT_FUNC_CALL_AMOUNT = 2000000 * 1000000;
+// Default value is set to equal to max_prepaid_gas as discussed here:
+// https://github.com/nearprotocol/nearlib/pull/191#discussion_r369671912
+const DEFAULT_FUNC_CALL_GAS = new bn_js_1.default("10000000000000000");
 // Default number of retries before giving up on a transactioin.
 const TX_STATUS_RETRY_NUMBER = 10;
 // Default wait until next retry in millis.
@@ -130,7 +136,7 @@ class Account {
     async functionCall(contractId, methodName, args, gas, amount) {
         args = args || {};
         this.validateArgs(args);
-        return this.signAndSendTransaction(contractId, [transaction_1.functionCall(methodName, Buffer.from(JSON.stringify(args)), gas || DEFAULT_FUNC_CALL_AMOUNT, amount)]);
+        return this.signAndSendTransaction(contractId, [transaction_1.functionCall(methodName, Buffer.from(JSON.stringify(args)), gas || DEFAULT_FUNC_CALL_GAS, amount)]);
     }
     // TODO: expand this API to support more options.
     async addKey(publicKey, contractId, methodName, amount) {

--- a/lib/transaction.d.ts
+++ b/lib/transaction.d.ts
@@ -52,7 +52,7 @@ declare class DeleteAccount extends IAction {
 }
 export declare function createAccount(): Action;
 export declare function deployContract(code: Uint8Array): Action;
-export declare function functionCall(methodName: string, args: Uint8Array, gas: number, deposit: BN): Action;
+export declare function functionCall(methodName: string, args: Uint8Array, gas: BN, deposit: BN): Action;
 export declare function transfer(deposit: BN): Action;
 export declare function stake(stake: BN, publicKey: PublicKey): Action;
 export declare function addKey(publicKey: PublicKey, accessKey: AccessKey): Action;

--- a/src.ts/account.ts
+++ b/src.ts/account.ts
@@ -15,7 +15,7 @@ import { parseRpcError } from './utils/rpc_errors';
 // the originator.
 // Default value is set to equal to max_prepaid_gas as discussed here:
 // https://github.com/nearprotocol/nearlib/pull/191#discussion_r369671912
-const DEFAULT_FUNC_CALL_GAS = new BN("10000000000000000");
+const DEFAULT_FUNC_CALL_GAS = new BN('10000000000000000');
 
 // Default number of retries before giving up on a transactioin.
 const TX_STATUS_RETRY_NUMBER = 10;

--- a/src.ts/account.ts
+++ b/src.ts/account.ts
@@ -10,10 +10,10 @@ import { PublicKey } from './utils/key_pair';
 import { PositionalArgsError } from './utils/errors';
 import { parseRpcError } from './utils/rpc_errors';
 
-// Default amount of tokens to be send with the function calls. Used to pay for the fees
+// Default amount of gas to be sent with the function calls. Used to pay for the fees
 // incurred while running the contract execution. The unused amount will be refunded back to
 // the originator.
-const DEFAULT_FUNC_CALL_AMOUNT = 2000000 * 1000000;
+const DEFAULT_FUNC_CALL_GAS = "100000000000000000";
 
 // Default number of retries before giving up on a transactioin.
 const TX_STATUS_RETRY_NUMBER = 10;
@@ -173,7 +173,7 @@ export class Account {
     async functionCall(contractId: string, methodName: string, args: any, gas: number, amount?: BN): Promise<FinalExecutionOutcome> {
         args = args || {};
         this.validateArgs(args);
-        return this.signAndSendTransaction(contractId, [functionCall(methodName, Buffer.from(JSON.stringify(args)), gas || DEFAULT_FUNC_CALL_AMOUNT, amount)]);
+        return this.signAndSendTransaction(contractId, [functionCall(methodName, Buffer.from(JSON.stringify(args)), gas || DEFAULT_FUNC_CALL_GAS, amount)]);
     }
 
     // TODO: expand this API to support more options.

--- a/src.ts/account.ts
+++ b/src.ts/account.ts
@@ -13,7 +13,9 @@ import { parseRpcError } from './utils/rpc_errors';
 // Default amount of gas to be sent with the function calls. Used to pay for the fees
 // incurred while running the contract execution. The unused amount will be refunded back to
 // the originator.
-const DEFAULT_FUNC_CALL_GAS = "100000000000000000";
+// Default value is set to equal to max_prepaid_gas as discussed here:
+// https://github.com/nearprotocol/nearlib/pull/191#discussion_r369671912
+const DEFAULT_FUNC_CALL_GAS = new BN("10000000000000000");
 
 // Default number of retries before giving up on a transactioin.
 const TX_STATUS_RETRY_NUMBER = 10;
@@ -170,7 +172,7 @@ export class Account {
         return this.signAndSendTransaction(this.accountId, [deployContract(data)]);
     }
 
-    async functionCall(contractId: string, methodName: string, args: any, gas: number, amount?: BN): Promise<FinalExecutionOutcome> {
+    async functionCall(contractId: string, methodName: string, args: any, gas?: BN, amount?: BN): Promise<FinalExecutionOutcome> {
         args = args || {};
         this.validateArgs(args);
         return this.signAndSendTransaction(contractId, [functionCall(methodName, Buffer.from(JSON.stringify(args)), gas || DEFAULT_FUNC_CALL_GAS, amount)]);

--- a/src.ts/contract.ts
+++ b/src.ts/contract.ts
@@ -28,7 +28,7 @@ export class Contract {
             Object.defineProperty(this, methodName, {
                 writable: false,
                 enumerable: true,
-                value: async function(args: any, gas?: number, amount?: BN) {
+                value: async function(args: any, gas?: BN, amount?: BN) {
                     if (arguments.length > 3) {
                         throw new PositionalArgsError();
                     }

--- a/src.ts/transaction.ts
+++ b/src.ts/transaction.ts
@@ -53,7 +53,7 @@ export function deployContract(code: Uint8Array): Action {
     return new Action({ deployContract: new DeployContract({code}) });
 }
 
-export function functionCall(methodName: string, args: Uint8Array, gas: number, deposit: BN): Action {
+export function functionCall(methodName: string, args: Uint8Array, gas: BN, deposit: BN): Action {
     return new Action({functionCall: new FunctionCall({methodName, args, gas, deposit }) });
 }
 


### PR DESCRIPTION
Set to 1/1000 of current `REACT_APP_ACCESS_KEY_FUNDING_AMOUNT` on testnet. 
So app can do 1000 transactions with default access key allowance.

Fixes https://github.com/nearprotocol/nearlib/issues/176