### PR TITLE
Allow creation of contracts with only view or change methods

### DIFF
--- a/src.ts/contract.ts
+++ b/src.ts/contract.ts
@@ -12,7 +12,8 @@ export class Contract {
     constructor(account: Account, contractId: string, options: { viewMethods: string[], changeMethods: string[] }) {
         this.account = account;
         this.contractId = contractId;
-        options.viewMethods.forEach((methodName) => {
+        const { viewMethods = [], changeMethods = [] } = options;
+        viewMethods.forEach((methodName) => {
             Object.defineProperty(this, methodName, {
                 writable: false,
                 enumerable: true,
@@ -24,7 +25,7 @@ export class Contract {
                 }
             });
         });
-        options.changeMethods.forEach((methodName) => {
+        changeMethods.forEach((methodName) => {
             Object.defineProperty(this, methodName, {
                 writable: false,
                 enumerable: true,

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -196,13 +196,13 @@ describe('with deploy contract', () => {
         const contract = new nearlib.Contract(workingAccount, contractId, {
             viewMethods: ['hello'],
         });
-        expect(await contract.hello({ name: 'world' }).toEqual('hello world');
+        expect(await contract.hello({ name: 'world' })).toEqual('hello world');
     });
     
     test('can have change methods only', async () => {
         const contract = new nearlib.Contract(workingAccount, contractId, {
             changeMethods: ['hello'],
         });
-        expect(await contract.hello({ name: 'world' }).toEqual('hello world');
+        expect(await contract.hello({ name: 'world' })).toEqual('hello world');
     });
 });

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -191,4 +191,18 @@ describe('with deploy contract', () => {
     test('test set/remove', async () => {
         await contract.testSetRemove({ value: '123' });
     });
+    
+    test('can have view methods only', async () => {
+        const contract = new nearlib.Contract(workingAccount, contractId, {
+            viewMethods: ['hello'],
+        });
+        expect(await contract.hello({ name: 'world' }).toEqual('hello world');
+    });
+    
+    test('can have change methods only', async () => {
+        const contract = new nearlib.Contract(workingAccount, contractId, {
+            changeMethods: ['hello'],
+        });
+        expect(await contract.hello({ name: 'world' }).toEqual('hello world');
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/nearprotocol/nearlib/issues/117