### PR TITLE
remove util for generating KeyPairs

### DIFF
--- a/src.ts/utils/index.ts
+++ b/src.ts/utils/index.ts
@@ -17,7 +17,5 @@ export {
     enums,
     format,
     PublicKey,
-    KeyPair,
-    KeyPairEd25519,
     rpc_errors
 };


### PR DESCRIPTION
Hiding the utils for KeyPair. Re: https://github.com/nearprotocol/nearlib/issues/208