### PR TITLE
Fix for empty error variants

### DIFF
--- a/lib/res/error_messages.json
+++ b/lib/res/error_messages.json
@@ -50,7 +50,7 @@
     "AddKeyAlreadyExists": "The public key {{public_key}} is already used for an existing access key",
     "InvalidSigner": "Invalid signer account ID {{signer_id}} according to requirements",
     "CreateAccountNotAllowed": "The new account_id {{account_id}} can't be created by {{predecessor_id}}",
-    "ActionError": "The used access key requires exactly one FunctionCall action",
+    "RequiresFullAccess": "The used access key requires exactly one FunctionCall action",
     "TriesToUnstake": "Account {{account_id}} is not yet staked, but tries to unstake",
     "InvalidNonce": "Transaction nonce {{tx_nonce}} must be larger than nonce of the used access key {{ak_nonce}}",
     "AccountAlreadyExists": "Can't create a new account {{account_id}}, because it already exists",

--- a/lib/utils/rpc_errors.js
+++ b/lib/utils/rpc_errors.js
@@ -39,6 +39,10 @@ function walkSubtype(errorObj, schema, result, typeName) {
     let type;
     let errorTypeName;
     for (const errorName in schema) {
+        if (isString(errorObj[errorName])) {
+            // Return early if error type is in a schema
+            return errorObj[errorName];
+        }
         if (isObject(errorObj[errorName])) {
             error = errorObj[errorName];
             type = schema[errorName];
@@ -65,4 +69,7 @@ function walkSubtype(errorObj, schema, result, typeName) {
 }
 function isObject(n) {
     return Object.prototype.toString.call(n) === '[object Object]';
+}
+function isString(n) {
+    return Object.prototype.toString.call(n) === '[object String]';
 }

--- a/src.ts/res/error_messages.json
+++ b/src.ts/res/error_messages.json
@@ -50,7 +50,7 @@
     "AddKeyAlreadyExists": "The public key {{public_key}} is already used for an existing access key",
     "InvalidSigner": "Invalid signer account ID {{signer_id}} according to requirements",
     "CreateAccountNotAllowed": "The new account_id {{account_id}} can't be created by {{predecessor_id}}",
-    "ActionError": "The used access key requires exactly one FunctionCall action",
+    "RequiresFullAccess": "The used access key requires exactly one FunctionCall action",
     "TriesToUnstake": "Account {{account_id}} is not yet staked, but tries to unstake",
     "InvalidNonce": "Transaction nonce {{tx_nonce}} must be larger than nonce of the used access key {{ak_nonce}}",
     "AccountAlreadyExists": "Can't create a new account {{account_id}}, because it already exists",

--- a/src.ts/utils/rpc_errors.ts
+++ b/src.ts/utils/rpc_errors.ts
@@ -28,6 +28,10 @@ function walkSubtype(errorObj, schema, result, typeName) {
     let type;
     let errorTypeName;
     for (const errorName in schema) {
+        if (isString(errorObj[errorName])) {
+            // Return early if error type is in a schema
+            return errorObj[errorName];
+        }
         if (isObject(errorObj[errorName])) {
             error = errorObj[errorName];
             type = schema[errorName];
@@ -52,4 +56,8 @@ function walkSubtype(errorObj, schema, result, typeName) {
 
 function isObject(n) {
     return Object.prototype.toString.call(n) === '[object Object]';
+}
+
+function isString(n) {
+    return Object.prototype.toString.call(n) === '[object String]';
 }

--- a/test/utils/rpc-errors.test.js
+++ b/test/utils/rpc-errors.test.js
@@ -10,6 +10,7 @@ const {
     FunctionCallError,
     HostError,
     InvalidIteratorIndex,
+    GasLimitExceeded,
     formatError
 } = nearlib.utils.rpc_errors;
 describe('rpc-errors', () => {
@@ -18,7 +19,7 @@ describe('rpc-errors', () => {
             TxExecutionError: {
                 ActionError: {
                     index: 1,
-                    kind: { AccountAlreadyExists: { account_id: 'bob.near' } }
+                    kind: {AccountAlreadyExists: {account_id: 'bob.near'}}
                 }
             }
         };
@@ -61,7 +62,7 @@ describe('rpc-errors', () => {
                 ActionError: {
                     FunctionCallError: {
                         HostError: {
-                            InvalidIteratorIndex: { iterator_index: 42 }
+                            InvalidIteratorIndex: {iterator_index: 42}
                         }
                     }
                 }
@@ -76,6 +77,28 @@ describe('rpc-errors', () => {
         expect(error instanceof InvalidIteratorIndex).toBe(true);
         expect(error.iterator_index).toBe(42);
         expect(formatError(error.type, error)).toBe('Iterator index 42 does not exist');
+    });
+
+    test('test ActionError::FunctionCallError::GasLimitExceeded error', async () => {
+        let rpc_error = {
+            ActionError: {
+                'index': 0,
+                'kind': {
+                    FunctionCallError: {
+                        'HostError': 'GasLimitExceeded'
+                    }
+                }
+            }
+        };
+        let error = parseRpcError(rpc_error);
+        expect(error instanceof TxExecutionError).toBe(true);
+
+        expect(error instanceof ActionError).toBe(true);
+        expect(error instanceof FunctionCallError).toBe(true);
+        expect(error instanceof HostError).toBe(true);
+        expect(error instanceof GasLimitExceeded).toBe(true);
+
+        expect(formatError(error.type, error)).toBe('Exceeded the maximum amount of gas allowed to burn per contract');
     });
 
 });


### PR DESCRIPTION
fixes https://github.com/nearprotocol/nearlib/issues/206
fixes https://github.com/nearprotocol/nearlib/issues/210

The problem was that serde serialize Enums differently:
for variants with data it serialize it as an object with a key which corresponds to a variant and value with data, but in case of variants w/o data it serializes as just a string. 

This checks if the key is a string and we have it in the schema.