### PR TITLE
refactor: clean up format tests

### DIFF
--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -4,51 +4,56 @@ const nearlib = require('../../lib/index');
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 50000;
 
-test('formatting yoctonear amounts', async() => {
-    expect(nearlib.utils.format.formatNearAmount('8999999999837087887')).toEqual('0.000008999999999837087887');
-    expect(nearlib.utils.format.formatNearAmount('8099099999837087887')).toEqual('0.000008099099999837087887');
-    expect(nearlib.utils.format.formatNearAmount('8099099999837087887')).not.toEqual('0.000008099099999837087888');
-    expect(nearlib.utils.format.formatNearAmount('999998999999999837087887000')).toEqual('999.998999999999837087887');
-    expect(nearlib.utils.format.formatNearAmount('1'+'0'.repeat(13))).toEqual('0.00000000001');
-    expect(nearlib.utils.format.formatNearAmount('9999989999999998370878870000000')).toEqual('9,999,989.99999999837087887');
-    expect(nearlib.utils.format.formatNearAmount('000000000000000000000000')).toEqual('0');
-    expect(nearlib.utils.format.formatNearAmount('1000000000000000000000000')).toEqual('1');
-    expect(nearlib.utils.format.formatNearAmount('999999999999999999000000')).toEqual('0.999999999999999999');
-    expect(nearlib.utils.format.formatNearAmount('999999999999999999000000', 10)).toEqual('1');
-    expect(nearlib.utils.format.formatNearAmount('1003000000000000000000000', 3)).toEqual('1.003');
-    expect(nearlib.utils.format.formatNearAmount('3000000000000000000000', 3)).toEqual('0.003');
-    expect(nearlib.utils.format.formatNearAmount('3000000000000000000000', 4)).toEqual('0.003'); 
-    expect(nearlib.utils.format.formatNearAmount('3500000000000000000000', 3)).toEqual('0.004');
-    expect(nearlib.utils.format.formatNearAmount('03500000000000000000000', 3)).toEqual('0.004');
-    expect(nearlib.utils.format.formatNearAmount('10000000999999997410000000')).toEqual('10.00000099999999741');
-    expect(nearlib.utils.format.formatNearAmount('10100000999999997410000000')).toEqual('10.10000099999999741');
-    expect(nearlib.utils.format.formatNearAmount('10040000999999997410000000', 2)).toEqual('10.04');
-    expect(nearlib.utils.format.formatNearAmount('10999000999999997410000000', 2)).toEqual('11');
-    expect(nearlib.utils.format.formatNearAmount('1000000100000000000000000000000')).toEqual('1,000,000.1');
-    expect(nearlib.utils.format.formatNearAmount('1000100000000000000000000000000')).toEqual('1,000,100');
-    expect(nearlib.utils.format.formatNearAmount('910000000000000000000000', 0)).toEqual('1');
+test.each`
+    balance                              | fracDigits   | expected
+    ${'8999999999837087887'}             | ${undefined} | ${'0.000008999999999837087887'}
+    ${'8099099999837087887'}             | ${undefined} | ${'0.000008099099999837087887'}
+    ${'999998999999999837087887000'}     | ${undefined} | ${'999.998999999999837087887'}
+    ${'1'+'0'.repeat(13)}                | ${undefined} | ${'0.00000000001'}
+    ${'9999989999999998370878870000000'} | ${undefined} | ${'9,999,989.99999999837087887'}
+    ${'000000000000000000000000'}        | ${undefined} | ${'0'}
+    ${'1000000000000000000000000'}       | ${undefined} | ${'1'}
+    ${'999999999999999999000000'}        | ${undefined} | ${'0.999999999999999999'}
+    ${'999999999999999999000000'}        | ${10}        | ${'1'}
+    ${'1003000000000000000000000'}       | ${3}         | ${'1.003'}
+    ${'3000000000000000000000'}          | ${3}         | ${'0.003'}
+    ${'3000000000000000000000'}          | ${4}         | ${'0.003'}
+    ${'3500000000000000000000'}          | ${3}         | ${'0.004'}
+    ${'03500000000000000000000'}         | ${3}         | ${'0.004'}
+    ${'10000000999999997410000000'}      | ${undefined} | ${'10.00000099999999741'}
+    ${'10100000999999997410000000'}      | ${undefined} | ${'10.10000099999999741'}
+    ${'10040000999999997410000000'}      | ${2}         | ${'10.04'}
+    ${'10999000999999997410000000'}      | ${2}         | ${'11'}
+    ${'1000000100000000000000000000000'} | ${undefined} | ${'1,000,000.1'}
+    ${'1000100000000000000000000000000'} | ${undefined} | ${'1,000,100'}
+    ${'910000000000000000000000'}        | ${0}         | ${'1'}
+`('formatNearAmount($balance, $fracDigits) returns $expected', ({ balance, fracDigits, expected }) => {
+    expect(nearlib.utils.format.formatNearAmount(balance, fracDigits)).toEqual(expected);
 });
 
-test('converting near to account balance units', async() => {
-    expect(nearlib.utils.format.parseNearAmount(null)).toEqual(null);
-    expect(nearlib.utils.format.parseNearAmount('5.3')).toEqual('5300000000000000000000000');
-    expect(nearlib.utils.format.parseNearAmount('5')).toEqual('5000000000000000000000000');
-    expect(nearlib.utils.format.parseNearAmount('1')).toEqual('1000000000000000000000000');
-    expect(nearlib.utils.format.parseNearAmount('10')).toEqual('10000000000000000000000000');
-    expect(nearlib.utils.format.parseNearAmount('0.000008999999999837087887')).toEqual('8999999999837087887');
-    expect(nearlib.utils.format.parseNearAmount('0.000008099099999837087887')).toEqual('8099099999837087887');
-    expect(nearlib.utils.format.parseNearAmount('0.000008099099999837087887')).not.toEqual('8099099999837087888');
-    expect(nearlib.utils.format.parseNearAmount('999.998999999999837087887000')).toEqual('999998999999999837087887000');
-    expect(nearlib.utils.format.parseNearAmount('0.000000000000001')).toEqual('1000000000');
-    expect(nearlib.utils.format.parseNearAmount('0.000001')).toEqual('1000000000000000000');
-    expect(nearlib.utils.format.parseNearAmount('.000001')).toEqual('1000000000000000000');
-    expect(nearlib.utils.format.parseNearAmount('000000.000001')).toEqual('1000000000000000000');
-    expect(nearlib.utils.format.parseNearAmount('1,000,000.1')).toEqual('1000000100000000000000000000000');
+test.each`
+    amt                               | expected
+    ${null}                           | ${null}
+    ${'5.3'}                          | ${'5300000000000000000000000'}
+    ${'5'}                            | ${'5000000000000000000000000'}
+    ${'1'}                            | ${'1000000000000000000000000'}
+    ${'10'}                           | ${'10000000000000000000000000'}
+    ${'0.000008999999999837087887'}   | ${'8999999999837087887'}
+    ${'0.000008099099999837087887'}   | ${'8099099999837087887'}
+    ${'999.998999999999837087887000'} | ${'999998999999999837087887000'}
+    ${'0.000000000000001'}            | ${'1000000000'}
+    ${'0.000001'}                     | ${'1000000000000000000'}
+    ${'.000001'}                      | ${'1000000000000000000'}
+    ${'000000.000001'}                | ${'1000000000000000000'}
+    ${'1,000,000.1'}                  | ${'1000000100000000000000000000000'}
+`('parseNearAmount($amt) returns $expected', ({ amt, expected }) => {
+    expect(nearlib.utils.format.parseNearAmount(amt)).toEqual(expected);
+});
 
-    try  {
-        // Too many decimals
-        expect(nearlib.utils.format.parseNearAmount('0.0000080990999998370878871')).toFail();
-    } catch (e) {
-        expect(e.toString()).toEqual('Error: Cannot parse \'0.0000080990999998370878871\' as NEAR amount');
-    }
+test('parseNearAmount fails when parsing values with ≥25 decimal places', () => {
+    expect(() => {
+        nearlib.utils.format.parseNearAmount('0.0000080990999998370878871');
+    }).toThrowError(
+        'Cannot parse \'0.0000080990999998370878871\' as NEAR amount'
+    );
 });


### PR DESCRIPTION
This uses Jest's `test.each` ([docs]) to format these tests as tables, which makes them easier to visually parse

Other improvements:

* remove unused & invalid `toFail()` matcher, replacing it with `toThrowError`
* remove unnecessary `async`s

  [docs]: https://jestjs.io/docs/en/api#testeachtablename-fn-timeout