### PR TITLE
fund account created with masterAccount with proper gas

### DIFF
--- a/lib/near.js
+++ b/lib/near.js
@@ -20,7 +20,9 @@ class Near {
         });
         if (config.masterAccount) {
             // TODO: figure out better way of specifiying initial balance.
-            this.accountCreator = new account_creator_1.LocalAccountCreator(new account_1.Account(this.connection, config.masterAccount), new bn_js_1.default(config.initialBalance) || new bn_js_1.default(1000 * 1000 * 1000 * 1000));
+            // Hardcoded number below is roughly five times the gas cost to dev-deploy with near-shell
+            const initialBalance = config.initialBalance ? new bn_js_1.default(config.initialBalance) : new bn_js_1.default('100000000000000000');
+            this.accountCreator = new account_creator_1.LocalAccountCreator(new account_1.Account(this.connection, config.masterAccount), initialBalance);
         }
         else if (config.helperUrl) {
             this.accountCreator = new account_creator_1.UrlAccountCreator(this.connection, config.helperUrl);

--- a/src.ts/near.ts
+++ b/src.ts/near.ts
@@ -22,7 +22,9 @@ export class Near {
         });
         if (config.masterAccount) {
             // TODO: figure out better way of specifiying initial balance.
-            this.accountCreator = new LocalAccountCreator(new Account(this.connection, config.masterAccount), new BN(config.initialBalance) || new BN(1000 * 1000 * 1000 * 1000));
+            // Hardcoded number below is roughly five times the gas cost to dev-deploy with near-shell
+            const initialBalance = config.initialBalance ? new BN(config.initialBalance) : new BN('100000000000000000');
+            this.accountCreator = new LocalAccountCreator(new Account(this.connection, config.masterAccount), initialBalance);
         } else if (config.helperUrl) {
             this.accountCreator = new UrlAccountCreator(this.connection, config.helperUrl);
         } else {


### PR DESCRIPTION
**Problem**: Commands that use `masterAccount` will fail with gas errors. This includes `near-shell` commands like `dev deploy`. See the issue opened by Illia: https://github.com/nearprotocol/near-shell/issues/271.

A simple way to reproduce this is to use `create-near-app` and run a `dev-deploy`

`npx create-near-app my-awesomely-broken-app`
install dependencies…
use `near login` for an account XYZ_NEAR.
then:
`near dev-deploy --masterAccount XYZ_NEAR`

You'll see this error:

> The account dev-123… wouldn't have enough balance to pay required rent 10920

Odd because that rent is super low.
There are a series of issues. The first issue is here:

https://github.com/nearprotocol/nearlib/blob/master/src.ts/near.ts#L25

We recently wrapped the `initialBalance` in a `BN()` which is from the `bn.js` dependency.

We'll never get to the right side of the `||` in that line because when it's wrapped like that, it's technically a valid object, a `BN` of value zero.

So first thing, that logic needs to be reworked to be:

```
const initialBalance = config.initialBalance ? new BN(config.initialBalance) : new BN(1000 * 1000 * 1000 * 1000);
this.accountCreator = new LocalAccountCreator(new Account(this.connection, config.masterAccount), initialBalance);
```

After that change, we get a little farther, but it's still not enough gas. Running the same `dev-deploy` command from before, we get the next error:

`Sender "dev-123…" does not have enough balance 999999999818 for operation costing 19706852093430000`

First off, that seems like a lot of gas, but that's perhaps beside the point for now.
Required vs current balance.

```
19706852093430000
00000999999999818
```

So we're 5 zeroes off, meaning if we want to provide this new account with a balance capable of deploying this contract, a simple way is to multiply by 100,000. This is just to make sure the deployment can go through.
Note that we have `new BN(1000 * 1000 * 1000 * 1000)` for this value.
Perhaps this is for readability multiplying like this? Anyway, in order to add 5 zeroes that would now be:

`new BN(1000 * 1000 * 1000 * 1000 * 1000 * 100)`

So run the `dev-deploy` command again and get another error:

```
Error: Assertion failed
    at assert (/Users/mike/tmp/cna-react-as/node_modules/bn.js/lib/bn.js:6:21)
```

That line in `bn.js` is:

```
function assert (val, msg) {
    if (!val) throw new Error(msg || 'Assertion failed');
  }
```

If you remove **two** zeroes than the assertion passes. So there's the upper limit.

That's because we all know there's a max limit to numbers in Javascript, which is why we're using `bn.js` in the first place.

**Side note**: this is where I also `rm neardev/dev-account` before running the `dev-deploy` command to ensure we're actually creating a new account from master account and funding it, otherwise it'll use the key it finds there.

So basically hardcoding to a value, and we need to use a string like `bn.js` expects. This is roughly 5 times the amount of gas that seems to be required to deploy this contract. Hence the hardcoded `'100000000000000000'` instead of the `1000 * 1000 …` style.