### PR TITLE
Removing `yarn audit` from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ script:
   - yarn lint
   - yarn test
   - yarn browserify && yarn run bundlewatch
-  - yarn audit
 


### PR DESCRIPTION
Looks like it gets in the way, e.g. these builds fail, but `yarn audit` stops failing after updating `yarn.lock`:
https://travis-ci.com/github/nearprotocol/nearlib/jobs/296530318
https://travis-ci.com/github/nearprotocol/nearlib/jobs/296530604

However it has nothing to do with security of library, as `yarn.lock` from this repo isn't honored when installing library as dependency.